### PR TITLE
Fixed issue not showing broadcast when kicking

### DIFF
--- a/src/main/java/net/cubespace/geSuit/managers/BansManager.java
+++ b/src/main/java/net/cubespace/geSuit/managers/BansManager.java
@@ -258,6 +258,8 @@ public class BansManager {
             } else {
             	PlayerManager.sendBroadcast(Utilities.colorize(ConfigManager.messages.KICK_PLAYER_BROADCAST.replace("{message}", reason).replace("{player}", t.dispname).replace("{sender}", sender.getName())), t.name);
             }
+        } else {
+            PlayerManager.sendMessageToTarget(sender, ConfigManager.messages.KICK_PLAYER_BROADCAST.replace("{message}", reason).replace("{player}", t.dispname).replace("{sender}", sender.getName()));
         }
     }
 


### PR DESCRIPTION
When kicking a player and not having BroadcastKicks enabled, the sender get's no feedback. Fixed in this version.